### PR TITLE
Update the JwtAuthDirective to extract the bearer token from the header

### DIFF
--- a/src/main/scala/de/innfactory/akka/jwt/AutoValidator.scala
+++ b/src/main/scala/de/innfactory/akka/jwt/AutoValidator.scala
@@ -8,6 +8,6 @@ import com.nimbusds.jwt.JWTClaimsSet
 class AutoValidator extends JwtValidator {
   override def validate(jwtToken: JwtToken) =
     Right(
-      (JwtToken("auto-validated"),
+      (jwtToken,
        JWTClaimsSet.parse("{\"sub\" : \"auto-validated\"}")))
 }

--- a/src/test/scala/de/innfactory/akka/JwtAuthDirectivesTest.scala
+++ b/src/test/scala/de/innfactory/akka/JwtAuthDirectivesTest.scala
@@ -16,7 +16,15 @@ class JwtAuthDirectivesTest extends WordSpec with Matchers with JwtAuthDirective
       val authRoute =  get { authenticate { token => complete(token._1.content) } }
 
       Get() ~> addHeader("Authorization", "any") ~> authRoute ~> check  {
-        responseAs[String] shouldBe("auto-validated")
+        responseAs[String] shouldBe("any")
+      }
+    }
+    "extract token from 'Bearer' type authorization header" in {
+      //like the runtime, instantiate route once
+      val authRoute =  get { authenticate { token => complete(token._1.content) } }
+
+      Get() ~> addHeader("Authorization", "Bearer mytoken") ~> authRoute ~> check  {
+        responseAs[String] shouldBe("mytoken")
       }
     }
   }

--- a/src/test/scala/de/innfactory/akka/jwt/AutoValidatorTest.scala
+++ b/src/test/scala/de/innfactory/akka/jwt/AutoValidatorTest.scala
@@ -6,7 +6,7 @@ class AutoValidatorTest  extends WordSpec with Matchers {
   "AutoValidator" should {
     "be sucessfull" in {
         val validator = new AutoValidator()
-        validator.validate(JwtToken("any")).right.get._1.content shouldBe("auto-validated")
+        validator.validate(JwtToken("any")).right.get._1.content shouldBe("any")
         validator.validate(JwtToken("any")).right.get._2.getSubject shouldBe("auto-validated")
      }
   }


### PR DESCRIPTION
This change will work when the Authorization header value is "Bearer {token}" or "{token}"